### PR TITLE
feat: cli supports peer id path

### DIFF
--- a/src/server/bin.js
+++ b/src/server/bin.js
@@ -33,6 +33,9 @@ async function run () {
     const peerData = fs.readFileSync(argv.peerId)
     const peerId = await PeerId.createFromJSON(JSON.parse(peerData))
     peerInfo = await PeerInfo.create(peerId)
+  } else {
+    log('You are using an automatically generated peer. \n')
+    log('If you want to keep the same address for the server you should provide a peerId with --peerId <jsonFilePath>')
   }
 
   // Add remaining addresses

--- a/src/server/bin.js
+++ b/src/server/bin.js
@@ -34,7 +34,7 @@ async function run () {
     const peerId = await PeerId.createFromJSON(JSON.parse(peerData))
     peerInfo = await PeerInfo.create(peerId)
   } else {
-    log('You are using an automatically generated peer. \n')
+    log('You are using an automatically generated peer.')
     log('If you want to keep the same address for the server you should provide a peerId with --peerId <jsonFilePath>')
   }
 

--- a/src/server/bin.js
+++ b/src/server/bin.js
@@ -2,17 +2,20 @@
 
 'use strict'
 
-// Usage: $0 [--libp2pMultiaddr <ma> ... <ma>] [--metricsMultiaddr <ma>] [--disableMetrics]
+// Usage: $0 [--peerId <jsonFilePath>] [--libp2pMultiaddr <ma> ... <ma>] [--metricsMultiaddr <ma>] [--disableMetrics]
 
 /* eslint-disable no-console */
 
 const debug = require('debug')
 const log = debug('libp2p:stardust:server:bin')
 
+const fs = require('fs')
 const http = require('http')
 const menoetius = require('menoetius')
 
 const multiaddr = require('multiaddr')
+const PeerId = require('peer-id')
+const PeerInfo = require('peer-info')
 const Server = require('.')
 
 const argv = require('minimist')(process.argv.slice(2))
@@ -25,6 +28,13 @@ async function run () {
   const libp2pMa = argv.libp2pMultiaddr || argv.lm || process.env.LIBP2PMA || '/ip6/::/tcp/5892/ws'
   const addresses = [multiaddr(libp2pMa)]
 
+  let peerInfo
+  if (argv.peerId) {
+    const peerData = fs.readFileSync(argv.peerId)
+    const peerId = await PeerId.createFromJSON(JSON.parse(peerData))
+    peerInfo = await PeerInfo.create(peerId)
+  }
+
   // Add remaining addresses
   if (argv.libp2pMultiaddr || argv.lm) {
     argv._.forEach((addr) => {
@@ -34,7 +44,7 @@ async function run () {
 
   let metricsServer
 
-  const server = new Server({ addresses, hasMetrics: metrics })
+  const server = new Server({ addresses, hasMetrics: metrics, peerInfo })
   await server.start()
 
   console.log('server peerID: ', server.libp2p.peerInfo.id.toB58String())


### PR DESCRIPTION
For having easy and automatic deploys while keeping the same address in the server, this PR adds support to provide a path for a `peer-id` JSON file.

It can be tested as follows:

```sh
> node src/server/bin.js --peerId test/fixtures/peer-server.json
```